### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 
 name: Python package
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Loofy147/Larouine/security/code-scanning/1](https://github.com/Loofy147/Larouine/security/code-scanning/1)

To fix this issue, you should add a `permissions` block to the workflow file, restricting the GITHUB_TOKEN to the least privilege necessary. Since the workflow only installs dependencies, runs linting, and tests, it does not require write access to repository contents, issues, or pull requests. Therefore, the best fix is to add `permissions: contents: read` at the workflow level (right after the `name` field and before the `on` field), which applies to all jobs in the workflow. This change ensures that the workflow cannot write to the repository using the GITHUB_TOKEN, aligning with the principle of least privilege.

No new methods, imports, or other changes are needed; simply add the permissions block in the YAML file as described.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
